### PR TITLE
RPH 1.109.1337.16563 makes EmergencyLight::Id public

### DIFF
--- a/LiveLights/Utils/SirenExtensions.cs
+++ b/LiveLights/Utils/SirenExtensions.cs
@@ -36,7 +36,7 @@ namespace LiveLights.Utils
 
         public static uint SirenSettingID(this EmergencyLighting els)
         {
-            return (uint)typeof(EmergencyLighting).GetProperty("Id", BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Instance).GetValue(els);
+            return (uint)typeof(EmergencyLighting).GetProperty("Id", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance).GetValue(els);
         }
 
         public static bool IsCustomSetting(this EmergencyLighting els)


### PR DESCRIPTION
Per the update announcement at https://www.lcpdfr.com/wiki/gta5/modding-after-title-update/